### PR TITLE
Fix bug on login

### DIFF
--- a/Controller/Front/CustomerController.php
+++ b/Controller/Front/CustomerController.php
@@ -43,7 +43,7 @@ class CustomerController extends BaseFrontController
     {
         $customerController = new BaseCustomerController();
         $customerController->setContainer($this->container);
-        $customerController->loginAction();
+        $response = $customerController->loginAction();
 
         if (! $this->getSecurityContext()->hasCustomerUser()) {
 
@@ -81,5 +81,7 @@ class CustomerController extends BaseFrontController
             }
 
         }
+        
+        return $response;
     }
 }


### PR DESCRIPTION
When you have this module, if a customer logs in with good identifiants in the mini login form, instead of being redirected to the page he were, it stays on `/login` and print the connexion form even if the user is connected.
